### PR TITLE
Added date attribute to domainAdvisory type

### DIFF
--- a/dkhm-2.0.xsd
+++ b/dkhm-2.0.xsd
@@ -85,6 +85,7 @@
     <complexType name="domainAdvisory">
     <attribute name="domain" type="token"/>
     <attribute name="advisory" type="token"/>
+    <attribute name="date" type="dateTime"/>
     </complexType>
 
     <!-- custom: Usertype enumeration -->


### PR DESCRIPTION
The latest domain info command will set this date to the domain deletion date, when a domain has been marked for deletion.